### PR TITLE
Add metadata to message object

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,43 @@ class PublishableModel < ActiveRecord::Base
 end
 ```
 
+### 7. Sending messages to Kafka directly
+
+`pheromone` provides a custom message object that sends messages to Kafka in a predefined format, to maintain consistency in the message fields.
+
+`Pheromone::Messaging::Message` can be initialized with the following arguments:
+ - `topic`: name of the topic to which the message is produced 
+ - `message`: the actual message itself
+ - `metadata`: any additional fields that must be sent along with the message
+ - `options`: producer options as described in Section 6
+ 
+ Of these fields, only `topic` and `message` are compulsory and the remaining two are optional.
+ 
+ Example usage:
+ 
+ ```
+   Pheromone::Messaging::Message.new(
+     topic: 'test_topic',
+     message: { message_text: 'test' },
+     metadata: { event_type: 'create' },
+     producer_options: { max_retries: 5 }
+   )
+ ```
+ 
+ This will send a message to `test_topic` in Kafka in the following format: 
+ 
+ ```
+  {
+    'event_type' => 'create',
+    'timestamp' => '2015-07-14T10:10:00.000+08:00',
+    'blob' => {
+      'message_text' => 'test'
+    }
+  }.to_json
+ ```
+
+As seen above `timestamp` will be added automatically to the main attributes along with the message metadata. The actual message will be encapsulated inside a key called `blob`.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/pheromone/messaging/message.rb
+++ b/lib/pheromone/messaging/message.rb
@@ -4,16 +4,30 @@ require 'waterdrop'
 module Pheromone
   module Messaging
     class Message
-      def initialize(topic:, message:, options: {})
+      def initialize(topic:, message:, metadata: {}, options: {})
         @topic = topic
-        @message = MessageFormatter.new(message).format
-        @options = options
+        @message = message
+        @options = options || {}
+        @metadata = metadata || {}
       end
 
-      attr_reader :topic, :message, :options
+      attr_reader :topic, :message, :options, :metadata
 
       def send!
-        ::WaterDrop::Message.new(topic, message, options).send!
+        ::WaterDrop::Message.new(
+          topic,
+          MessageFormatter.new(full_message).format,
+          options
+        ).send!
+      end
+
+      private
+
+      def full_message
+        @metadata.merge!(
+          timestamp: Time.now,
+          blob: @message
+        )
       end
     end
   end

--- a/lib/pheromone/messaging/message_dispatcher.rb
+++ b/lib/pheromone/messaging/message_dispatcher.rb
@@ -38,6 +38,7 @@ module Pheromone
         Message.new(
           topic: @message_parameters[:topic],
           message: @message_parameters[:message],
+          metadata: @message_parameters[:metadata],
           options: @message_parameters[:producer_options] || {}
         )
       end

--- a/lib/pheromone/publishable.rb
+++ b/lib/pheromone/publishable.rb
@@ -66,11 +66,14 @@ module Pheromone
         options[:event_types].any? { |event| event == current_event }
       end
 
+      # Manages the actual formatting and sending of messages. By default messages are sent in
+      # sync mode. To override this, provide dispatch_method as :async
       def send_message(options)
         Pheromone::Messaging::MessageDispatcher.new(
           message_parameters: {
             topic: options[:topic],
-            message: message_meta_data.merge!(blob: message_blob(options)),
+            message: message_blob(options),
+            metadata: message_meta_data,
             producer_options: options[:producer_options]
           },
           dispatch_method: options[:dispatch_method] || :sync
@@ -80,8 +83,7 @@ module Pheromone
       def message_meta_data
         {
           event: current_event,
-          entity: self.class.name,
-          timestamp: Time.now
+          entity: self.class.name
         }
       end
 

--- a/lib/pheromone/version.rb
+++ b/lib/pheromone/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Pheromone
-  VERSION = '0.2.5'.freeze
+  VERSION = '0.2.6'.freeze
 end

--- a/spec/pheromone/messaging/message_dispatcher_spec.rb
+++ b/spec/pheromone/messaging/message_dispatcher_spec.rb
@@ -41,7 +41,7 @@ describe Pheromone::Messaging::MessageDispatcher do
         ).dispatch
         expect(@klass).to eq(ResqueJob)
         expect(@message.topic).to eq(:test_topic)
-        expect(@message.message).to eq("\"test_message\"")
+        expect(@message.message).to eq('test_message')
         expect(@message.options).to eq({})
       end
     end
@@ -69,11 +69,11 @@ describe Pheromone::Messaging::MessageDispatcher do
       end
       it 'invokes perform_async on sidekiq job with message fields' do
         described_class.new(
-            message_parameters: message_parameters,
-            dispatch_method: :async
+          message_parameters: message_parameters,
+          dispatch_method: :async
         ).dispatch
         expect(@message.topic).to eq(:test_topic)
-        expect(@message.message).to eq("\"test_message\"")
+        expect(@message.message).to eq('test_message')
         expect(@message.options).to eq({})
       end
     end
@@ -95,13 +95,17 @@ describe Pheromone::Messaging::MessageDispatcher do
       expect(instance_double).to receive(:send!)
     end
 
+    around { |example| Timecop.freeze(Time.local(2015, 7, 14, 10, 10), &example) }
+
     it 'sends message using waterdrop' do
       described_class.new(
-          message_parameters: message_parameters,
-          dispatch_method: :sync
+        message_parameters: message_parameters,
+        dispatch_method: :sync
       ).dispatch
       expect(@topic).to eq(:test_topic)
-      expect(@message).to eq("\"test_message\"")
+      expect(@message).to eq(
+        "{\"timestamp\":\"2015-07-14T02:10:00.000Z\",\"blob\":\"test_message\"}"
+      )
       expect(@options).to eq({})
     end
   end

--- a/spec/pheromone/messaging/message_spec.rb
+++ b/spec/pheromone/messaging/message_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+require 'pheromone/messaging/message'
+describe Pheromone::Messaging::Message do
+  before do
+    Pheromone::Config.configure do |config|
+      config.message_format = :json
+      config.timezone = 'Singapore'
+    end
+    @message = {
+      server_time: Time.zone,
+      message_data: {
+        event_time: Time.now,
+        text: 'message_text'
+      }
+    }
+    @meta_data = {
+      event_name: 'create'
+    }
+    @options = { max_retries: 5 }
+    @topic = :test
+  end
+
+  around { |example| Timecop.freeze(Time.local(2015, 7, 14, 10, 10), &example) }
+
+  context 'no metadata is provided' do
+    it 'uses default metadata' do
+      message_object = described_class.new(
+        topic: @topic,
+        message: @message,
+        options: @options
+      )
+      expect(WaterDrop::Message).to receive(:new).with(
+        :test,
+        {
+          'timestamp' => '2015-07-14T10:10:00.000+08:00',
+          'blob' => {
+            'server_time' => nil,
+            'message_data' => {
+              'event_time' => '2015-07-14T10:10:00.000+08:00',
+              'text' => 'message_text'
+            }
+          }
+        }.to_json,
+        { max_retries: 5 }
+      ).and_return(double(send!: nil))
+      message_object.send!
+    end
+  end
+
+  context 'no options are provided' do
+    it 'uses default options' do
+      message_object = described_class.new(
+        topic: @topic,
+        message: @message,
+        metadata: @meta_data
+      )
+      expect(WaterDrop::Message).to receive(:new).with(
+        :test,
+        {
+          'event_name' => 'create',
+          'timestamp' => '2015-07-14T10:10:00.000+08:00',
+          'blob' => {
+            'server_time' => nil,
+            'message_data' => {
+              'event_time' => '2015-07-14T10:10:00.000+08:00',
+              'text' => 'message_text'
+            }
+          }
+        }.to_json,
+        {}
+      ).and_return(double(send!: nil))
+      message_object.send!
+    end
+  end
+
+  context 'both metadata and options are provided' do
+    it 'sends all the message data to waterdrop' do
+      message_object = described_class.new(
+        topic: @topic,
+        message: @message,
+        metadata: @meta_data,
+        options: @options
+      )
+      expect(WaterDrop::Message).to receive(:new).with(
+        :test,
+        {
+          'event_name' => 'create',
+          'timestamp' => '2015-07-14T10:10:00.000+08:00',
+          'blob' => {
+            'server_time' => nil,
+            'message_data' => {
+              'event_time' => '2015-07-14T10:10:00.000+08:00',
+              'text' => 'message_text'
+            }
+          }
+        }.to_json,
+        { max_retries: 5 }
+      ).and_return(double(send!: nil))
+      message_object.send!
+    end
+  end
+end


### PR DESCRIPTION
## Why is this change necessary?

- Message object should provide a consistent formatting of messages. So both `publishable` concern and direct usage of message object can ensure that certain fields in the message are always present. These include timestamp, blob, and any other message metadata

## How does it address the issue?

- Adds metadata and blob to a message object

## What side effects does this change have?

- none