### PR TITLE
Pass message parameters as hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ Create a new class and add the name under `Pheromone.config.background_processor
  class ResqueJob
    @queue = :low
 
-   def self.perform(topic:, message:, metadata: {}, options: {})
+   def self.perform(message_object)
      Pheromone::Messaging::Message.new(
-       topic: topic,
-       message: message,
-       metadata: metadata,
-       options: options
+       topic: message_object[:topic],
+       message: message_object[:message],
+       metadata: message_object[:metadata],
+       options: message_object[:options]
      ).send!
    end
  end
@@ -112,12 +112,12 @@ Create a new class and add the name under `Pheromone.config.background_processor
 ```
  class SidekiqJob
    include Sidekiq::Worker
-   def perform(topic:, message:, metadata: {}, options: {})
+   def perform(message_object)
      Pheromone::Messaging::Message.new(
-       topic: topic,
-       message: message,
-       metadata: metadata,
-       options: options
+       topic: message_object[:topic],
+       message: message_object[:message],
+       metadata: message_object[:metadata],
+       options: message_object[:options]
      ).send!
    end
  end

--- a/README.md
+++ b/README.md
@@ -96,8 +96,13 @@ Create a new class and add the name under `Pheromone.config.background_processor
  class ResqueJob
    @queue = :low
 
-   def self.perform(message)
-     message.send!
+   def self.perform(topic:, message:, metadata: {}, options: {})
+     Pheromone::Messaging::Message.new(
+       topic: topic,
+       message: message,
+       metadata: metadata,
+       options: options
+     ).send!
    end
  end
 ```
@@ -107,8 +112,13 @@ Create a new class and add the name under `Pheromone.config.background_processor
 ```
  class SidekiqJob
    include Sidekiq::Worker
-   def perform(message)
-     message.send!
+   def perform(topic:, message:, metadata: {}, options: {})
+     Pheromone::Messaging::Message.new(
+       topic: topic,
+       message: message,
+       metadata: metadata,
+       options: options
+     ).send!
    end
  end
 ```

--- a/lib/pheromone/messaging/message_dispatcher.rb
+++ b/lib/pheromone/messaging/message_dispatcher.rb
@@ -28,19 +28,23 @@ module Pheromone
       # messages to Kafka
       def send_message_asynchronously
         if background_processor.name == :resque
-          Resque.enqueue(background_processor_klass, message)
+          Resque.enqueue(background_processor_klass, message_body)
         elsif background_processor.name == :sidekiq
-          background_processor_klass.perform_async(message)
+          background_processor_klass.perform_async(message_body)
         end
       end
 
       def message
-        Message.new(
+        Message.new(message_body)
+      end
+
+      def message_body
+        {
           topic: @message_parameters[:topic],
           message: @message_parameters[:message],
           metadata: @message_parameters[:metadata],
           options: @message_parameters[:producer_options] || {}
-        )
+        }
       end
 
       def background_processor

--- a/lib/pheromone/messaging/message_dispatcher.rb
+++ b/lib/pheromone/messaging/message_dispatcher.rb
@@ -1,6 +1,7 @@
 require 'pheromone'
 require 'pheromone/messaging/message_formatter'
 require 'pheromone/messaging/message'
+
 # This module is used for sending messages to Kafka
 # Dispatch method can be :sync or :async
 # When dispatch_method is async, the message object is passed to a job

--- a/lib/pheromone/templates/resque_job.rb.example
+++ b/lib/pheromone/templates/resque_job.rb.example
@@ -1,7 +1,12 @@
 # class ResqueJob
 #   @queue = :low
 #
-#   def self.perform(message)
-#     message.send!
+#   def self.perform(topic:, message:, metadata: {}, options: {})
+#     Pheromone::Messaging::Message.new(
+#        topic: topic,
+#        message: message,
+#        metadata: metadata,
+#        options: options
+#      ).send!
 #   end
 # end

--- a/lib/pheromone/templates/resque_job.rb.example
+++ b/lib/pheromone/templates/resque_job.rb.example
@@ -1,12 +1,12 @@
 # class ResqueJob
 #   @queue = :low
 #
-#   def self.perform(topic:, message:, metadata: {}, options: {})
+#   def self.perform(message_object)
 #     Pheromone::Messaging::Message.new(
-#        topic: topic,
-#        message: message,
-#        metadata: metadata,
-#        options: options
+#        topic: message_object[:topic],
+#        message: message_object[:message],
+#        metadata: message_object[:metadata],
+#        options: message_object[:options]
 #      ).send!
 #   end
 # end

--- a/lib/pheromone/templates/sidekiq_job.rb.example
+++ b/lib/pheromone/templates/sidekiq_job.rb.example
@@ -1,11 +1,11 @@
 # class SidekiqJob
 #   include Sidekiq::Worker
-#   def perform(topic:, message:, metadata: {}, options: {})
+#   def perform(message_object)
 #     Pheromone::Messaging::Message.new(
-#        topic: topic,
-#        message: message,
-#        metadata: metadata,
-#        options: options
+#        topic: message_object[:topic],
+#        message: message_object[:message],
+#        metadata: message_object[:metadata],
+#        options: message_object[:options]
 #      ).send!
 #   end
 # end

--- a/lib/pheromone/templates/sidekiq_job.rb.example
+++ b/lib/pheromone/templates/sidekiq_job.rb.example
@@ -1,6 +1,11 @@
 # class SidekiqJob
 #   include Sidekiq::Worker
-#   def perform(message)
-#     message.send!
+#   def perform(topic:, message:, metadata: {}, options: {})
+#     Pheromone::Messaging::Message.new(
+#        topic: topic,
+#        message: message,
+#        metadata: metadata,
+#        options: options
+#      ).send!
 #   end
 # end

--- a/lib/pheromone/version.rb
+++ b/lib/pheromone/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Pheromone
-  VERSION = '0.2.6'.freeze
+  VERSION = '0.2.7'.freeze
 end


### PR DESCRIPTION
## Why is this change necessary?

Background jobs end up deserializing the object passed in to them. So it's best to pash hash arguments and compose message object from within the job

## How does it address the issue?

Creates message object within the job

## What side effects does this change have?

none