### PR TITLE
Change parameter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Create a new class and add the name under `Pheromone.config.background_processor
    def self.perform(message_object)
      Pheromone::Messaging::Message.new(
        topic: message_object[:topic],
-       message: message_object[:message],
+       blob: message_object[:message],
        metadata: message_object[:metadata],
        options: message_object[:options]
      ).send!
@@ -115,7 +115,7 @@ Create a new class and add the name under `Pheromone.config.background_processor
    def perform(message_object)
      Pheromone::Messaging::Message.new(
        topic: message_object[:topic],
-       message: message_object[:message],
+       blob: message_object[:message],
        metadata: message_object[:metadata],
        options: message_object[:options]
      ).send!
@@ -315,7 +315,7 @@ end
 
 `Pheromone::Messaging::Message` can be initialized with the following arguments:
  - `topic`: name of the topic to which the message is produced 
- - `message`: the actual message itself
+ - `blob`: the actual message itself
  - `metadata`: any additional fields that must be sent along with the message
  - `options`: producer options as described in Section 6
  
@@ -326,7 +326,7 @@ end
  ```
    Pheromone::Messaging::Message.new(
      topic: 'test_topic',
-     message: { message_text: 'test' },
+     blob: { message_text: 'test' },
      metadata: { event_type: 'create' },
      producer_options: { max_retries: 5 }
    ).send!

--- a/lib/pheromone/messaging/message.rb
+++ b/lib/pheromone/messaging/message.rb
@@ -4,14 +4,14 @@ require 'waterdrop'
 module Pheromone
   module Messaging
     class Message
-      def initialize(topic:, message:, metadata: {}, options: {})
+      def initialize(topic:, blob:, metadata: {}, options: {})
         @topic = topic
-        @message = message
+        @blob = blob
         @options = options || {}
         @metadata = metadata || {}
       end
 
-      attr_reader :topic, :message, :options, :metadata
+      attr_reader :topic, :blob, :options, :metadata
 
       def send!
         ::WaterDrop::Message.new(
@@ -26,7 +26,7 @@ module Pheromone
       def full_message
         @metadata.merge!(
           timestamp: Time.now,
-          blob: @message
+          blob: @blob
         )
       end
     end

--- a/lib/pheromone/messaging/message_dispatcher.rb
+++ b/lib/pheromone/messaging/message_dispatcher.rb
@@ -42,7 +42,7 @@ module Pheromone
       def message_body
         {
           topic: @message_parameters[:topic],
-          message: @message_parameters[:message],
+          blob: @message_parameters[:blob],
           metadata: @message_parameters[:metadata],
           options: @message_parameters[:producer_options] || {}
         }

--- a/lib/pheromone/publishable.rb
+++ b/lib/pheromone/publishable.rb
@@ -72,7 +72,7 @@ module Pheromone
         Pheromone::Messaging::MessageDispatcher.new(
           message_parameters: {
             topic: options[:topic],
-            message: message_blob(options),
+            blob: message_blob(options),
             metadata: message_meta_data,
             producer_options: options[:producer_options]
           },

--- a/lib/pheromone/templates/resque_job.rb.example
+++ b/lib/pheromone/templates/resque_job.rb.example
@@ -4,7 +4,7 @@
 #   def self.perform(message_object)
 #     Pheromone::Messaging::Message.new(
 #        topic: message_object[:topic],
-#        message: message_object[:message],
+#        blob: message_object[:message],
 #        metadata: message_object[:metadata],
 #        options: message_object[:options]
 #      ).send!

--- a/lib/pheromone/version.rb
+++ b/lib/pheromone/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Pheromone
-  VERSION = '0.2.7'.freeze
+  VERSION = '0.2.u'.freeze
 end

--- a/spec/pheromone/messaging/message_dispatcher_spec.rb
+++ b/spec/pheromone/messaging/message_dispatcher_spec.rb
@@ -8,7 +8,7 @@ describe Pheromone::Messaging::MessageDispatcher do
   let(:message_parameters) do
     {
       topic: :test_topic,
-      message: 'test_message'
+      blob: 'test_message'
     }
   end
 
@@ -22,7 +22,7 @@ describe Pheromone::Messaging::MessageDispatcher do
           def self.perform(topic:, message:, metadata: {}, options: {})
             Pheromone::Messaging::Message.new(
               topic: topic,
-              message: message,
+              blob: message,
               metadata: metadata,
               options: options
             ).send!
@@ -47,7 +47,7 @@ describe Pheromone::Messaging::MessageDispatcher do
         ).dispatch
         expect(@klass).to eq(ResqueJob)
         expect(@message[:topic]).to eq(:test_topic)
-        expect(@message[:message]).to eq('test_message')
+        expect(@message[:blob]).to eq('test_message')
         expect(@message[:options]).to eq({})
       end
     end
@@ -61,7 +61,7 @@ describe Pheromone::Messaging::MessageDispatcher do
           def perform(topic:, message:, metadata: {}, options: {})
             Pheromone::Messaging::Message.new(
               topic: topic,
-              message: message,
+              blob: message,
               metadata: metadata,
               options: options
             ).send!
@@ -84,7 +84,7 @@ describe Pheromone::Messaging::MessageDispatcher do
           dispatch_method: :async
         ).dispatch
         expect(@message[:topic]).to eq(:test_topic)
-        expect(@message[:message]).to eq('test_message')
+        expect(@message[:blob]).to eq('test_message')
         expect(@message[:options]).to eq({})
       end
     end

--- a/spec/pheromone/messaging/message_spec.rb
+++ b/spec/pheromone/messaging/message_spec.rb
@@ -26,7 +26,7 @@ describe Pheromone::Messaging::Message do
     it 'uses default metadata' do
       message_object = described_class.new(
         topic: @topic,
-        message: @message,
+        blob: @message,
         options: @options
       )
       expect(WaterDrop::Message).to receive(:new).with(
@@ -51,7 +51,7 @@ describe Pheromone::Messaging::Message do
     it 'uses default options' do
       message_object = described_class.new(
         topic: @topic,
-        message: @message,
+        blob: @message,
         metadata: @meta_data
       )
       expect(WaterDrop::Message).to receive(:new).with(
@@ -77,7 +77,7 @@ describe Pheromone::Messaging::Message do
     it 'sends all the message data to waterdrop' do
       message_object = described_class.new(
         topic: @topic,
-        message: @message,
+        blob: @message,
         metadata: @meta_data,
         options: @options
       )


### PR DESCRIPTION
Why is this change necessary?

- For clarity purposes, it's better to call message as blob so there is no collision with the `Message` class

How does it address the issue?

- Changes the attribute name

What side effects does this change have?

None