### PR TITLE
Add encoding logic

### DIFF
--- a/lib/pheromone/messaging/message.rb
+++ b/lib/pheromone/messaging/message.rb
@@ -2,28 +2,21 @@
 module Pheromone
   module Messaging
     class Message
-      def initialize(topic:, blob:, metadata: {}, options: {})
+      def initialize(topic:, blob:, metadata: {}, options: {}, encoder: nil)
         @topic = topic
         @blob = blob
         @options = options || {}
         @metadata = metadata || {}
+        @encoder = encoder
       end
 
       attr_reader :topic, :blob, :options, :metadata
 
       def send!
+        binding.pry
         WaterDrop::SyncProducer.call(
-          MessageFormatter.new(full_message).format,
+          MessageFormatter.new({ metadata: @metadata, blob: @blob }, encoder: @encoder).format,
           { topic: topic.to_s }.merge!(options)
-        )
-      end
-
-      private
-
-      def full_message
-        @metadata.merge!(
-          timestamp: Time.now,
-          blob: @blob
         )
       end
     end

--- a/lib/pheromone/messaging/message.rb
+++ b/lib/pheromone/messaging/message.rb
@@ -2,20 +2,24 @@
 module Pheromone
   module Messaging
     class Message
-      def initialize(topic:, blob:, metadata: {}, options: {}, encoder: nil)
+      def initialize(topic:, blob:, metadata: {}, options: {}, encoder:, message_format:)
         @topic = topic
         @blob = blob
         @options = options || {}
         @metadata = metadata || {}
         @encoder = encoder
+        @message_format = message_format
       end
 
       attr_reader :topic, :blob, :options, :metadata
 
       def send!
-        binding.pry
         WaterDrop::SyncProducer.call(
-          MessageFormatter.new({ metadata: @metadata, blob: @blob }, encoder: @encoder).format,
+          MessageFormatter.new(
+            { metadata: @metadata, blob: @blob },
+            @encoder,
+            @message_format
+          ).format,
           { topic: topic.to_s }.merge!(options)
         )
       end

--- a/lib/pheromone/messaging/message_dispatcher.rb
+++ b/lib/pheromone/messaging/message_dispatcher.rb
@@ -17,9 +17,11 @@ module Pheromone
       def dispatch
         return unless Pheromone.enabled?
         if @dispatch_method == :sync
-          binding.pry
           Message.new(
-            message_body.merge!(encoder: @message_parameters[:encoder])
+            message_body.merge!(
+              encoder: @message_parameters[:encoder],
+              message_format: @message_parameters[:message_format]
+            )
           ).send!
         elsif @dispatch_method == :async
           send_message_asynchronously

--- a/lib/pheromone/messaging/message_dispatcher.rb
+++ b/lib/pheromone/messaging/message_dispatcher.rb
@@ -46,7 +46,8 @@ module Pheromone
           topic: @message_parameters[:topic],
           blob: @message_parameters[:blob],
           metadata: @message_parameters[:metadata],
-          options: @message_parameters[:producer_options] || {}
+          options: @message_parameters[:producer_options] || {},
+          embed_blob: @message_parameters[:embed_blob]
         }
       end
 

--- a/lib/pheromone/messaging/message_dispatcher.rb
+++ b/lib/pheromone/messaging/message_dispatcher.rb
@@ -17,7 +17,10 @@ module Pheromone
       def dispatch
         return unless Pheromone.enabled?
         if @dispatch_method == :sync
-          message.send!
+          binding.pry
+          Message.new(
+            message_body.merge!(encoder: @message_parameters[:encoder])
+          ).send!
         elsif @dispatch_method == :async
           send_message_asynchronously
         end
@@ -34,10 +37,6 @@ module Pheromone
         elsif background_processor.name == :sidekiq
           background_processor_klass.perform_async(message_body)
         end
-      end
-
-      def message
-        Message.new(message_body)
       end
 
       def message_body

--- a/lib/pheromone/messaging/message_formatter.rb
+++ b/lib/pheromone/messaging/message_formatter.rb
@@ -2,21 +2,35 @@ require 'pheromone/exceptions/unsupported_message_format'
 module Pheromone
   module Messaging
     class MessageFormatter
-      SUPPORTED_MESSAGE_FORMATS = [:json].freeze
+      include Pheromone::MethodInvoker
+      SUPPORTED_MESSAGE_FORMATS = [:json, :avro].freeze
 
-      def initialize(message)
+      def initialize(message, encoder)
         @message = message
+        @encoder = encoder
       end
 
       def format
-        if Pheromone.config.message_format == :json
+        if message_format == :json
           convert_to_time_format.to_json
+        elsif message_format == :avro
+          call_proc_or_instance_method(@encoder, convert_to_time_format)
         elsif !SUPPORTED_MESSAGE_FORMATS.include?(Pheromone.config.message_format)
           raise Pheromone::Exceptions::UnsupportedMessageFormat.new
         end
       end
 
       private
+
+      def message_format
+        Pheromone.config.message_format
+      end
+
+      # encodes message if encoding is specified
+      def encoded_message
+        message = convert_to_time_format
+
+      end
 
       # recursively converts time to the timezone set in configuration
       def convert_to_time_format

--- a/lib/pheromone/method_invoker.rb
+++ b/lib/pheromone/method_invoker.rb
@@ -6,8 +6,8 @@ module Pheromone
       # which is difficult to avoid since it handles
       # either a lambda/Proc or a named method from the including
       # class.
-      def call_proc_or_instance_method(proc_or_symbol)
-        return proc_or_symbol.call(self) if proc_or_symbol.respond_to?(:call)
+      def call_proc_or_instance_method(proc_or_symbol, argument = nil)
+        return proc_or_symbol.call(argument || self) if proc_or_symbol.respond_to?(:call)
         unless respond_to? proc_or_symbol
           raise "Method #{proc_or_symbol} not found for #{self.class.name}"
         end

--- a/lib/pheromone/publishable.rb
+++ b/lib/pheromone/publishable.rb
@@ -86,6 +86,7 @@ module Pheromone
             topic: options[:topic],
             blob: message_blob(options),
             metadata: message_meta_data(options, current_event),
+            encoder: options[:encoder],
             producer_options: options[:producer_options]
           },
           dispatch_method: options[:dispatch_method] || :sync
@@ -94,7 +95,7 @@ module Pheromone
 
       def message_meta_data(options, current_event)
         metadata = options[:metadata]
-        default_metadata = { event: current_event, entity: self.class.name }
+        default_metadata = { event: current_event, entity: self.class.name, timestamp: Time.now }
         return default_metadata if metadata.blank?
         provided_metadata = metadata.is_a?(Hash) ? metadata : call_proc_or_instance_method(metadata)
         default_metadata.merge!(provided_metadata)

--- a/lib/pheromone/publishable.rb
+++ b/lib/pheromone/publishable.rb
@@ -88,7 +88,8 @@ module Pheromone
             metadata: message_meta_data(options, current_event),
             encoder: options[:encoder],
             message_format: options[:message_format],
-            producer_options: options[:producer_options]
+            producer_options: options[:producer_options],
+            embed_blob: options[:embed_blob]
           },
           dispatch_method: options[:dispatch_method] || :sync
         ).dispatch

--- a/lib/pheromone/publishable.rb
+++ b/lib/pheromone/publishable.rb
@@ -87,6 +87,7 @@ module Pheromone
             blob: message_blob(options),
             metadata: message_meta_data(options, current_event),
             encoder: options[:encoder],
+            message_format: options[:message_format],
             producer_options: options[:producer_options]
           },
           dispatch_method: options[:dispatch_method] || :sync
@@ -95,7 +96,7 @@ module Pheromone
 
       def message_meta_data(options, current_event)
         metadata = options[:metadata]
-        default_metadata = { event: current_event, entity: self.class.name, timestamp: Time.now }
+        default_metadata = { event: current_event.to_s, entity: self.class.name, timestamp: Time.now }
         return default_metadata if metadata.blank?
         provided_metadata = metadata.is_a?(Hash) ? metadata : call_proc_or_instance_method(metadata)
         default_metadata.merge!(provided_metadata)

--- a/lib/pheromone/version.rb
+++ b/lib/pheromone/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Pheromone
-  VERSION = '0.4.5'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/pheromone.gemspec
+++ b/pheromone.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sidekiq'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'timecop', '~> 0.8'
-  spec.add_development_dependency 'with_model', '~> 1.2'
+  spec.add_development_dependency 'with_model', '~> 1.2.1'
 end

--- a/spec/pheromone/messaging/message_formatter_spec.rb
+++ b/spec/pheromone/messaging/message_formatter_spec.rb
@@ -11,7 +11,7 @@ describe Pheromone::Messaging::MessageFormatter do
     end
     it 'raises an error' do
       expect do
-        described_class.new('message').format
+        described_class.new('message', nil, nil).format
       end.to raise_error(
         Pheromone::Exceptions::UnsupportedMessageFormat,
         'Message format not supported'
@@ -19,7 +19,7 @@ describe Pheromone::Messaging::MessageFormatter do
     end
   end
 
-  context 'supported message format' do
+  context 'json message format' do
     before do
       Pheromone::Config.configure do |config|
         config.message_format = :json
@@ -28,18 +28,22 @@ describe Pheromone::Messaging::MessageFormatter do
     end
     it 'formats the message to json format' do
       expect(
-        described_class.new('{ message: 1 }').format
+        described_class.new('{ message: 1 }', nil, nil).format
       ).to eq("\"{ message: 1 }\"")
     end
 
     let(:result) do
       described_class.new(
-        current_time: Time.parse('2017-08-24 09:27:33 UTC'),
-        time_array: [ Time.parse('2017-08-24 10:00 UTC') ],
-        message: {
-          blob: 'blob',
-          time: { now: Time.parse('2017-08-24 10:00 UTC') }
-        }
+        {
+          current_time: Time.parse('2017-08-24 09:27:33 UTC'),
+          time_array: [ Time.parse('2017-08-24 10:00 UTC') ],
+          message: {
+            blob: 'blob',
+            time: { now: Time.parse('2017-08-24 10:00 UTC') }
+          }
+        },
+        nil,
+        nil
       ).format
     end
 
@@ -50,6 +54,43 @@ describe Pheromone::Messaging::MessageFormatter do
           'blob' => 'blob', 'time' => { 'now' => '2017-08-24T18:00:00.000+08:00' } },
         'time_array' => ['2017-08-24T18:00:00.000+08:00'],
       })
+    end
+  end
+
+  context 'with_encoding message format' do
+    before do
+      Pheromone::Config.configure do |config|
+        config.message_format = :json
+        config.timezone = 'Singapore'
+      end
+    end
+    it 'formats the message to json format' do
+      expect(
+        described_class.new('{ message: 1 }', nil, nil).format
+      ).to eq("\"{ message: 1 }\"")
+    end
+
+    let(:result) do
+      described_class.new(
+        {
+          current_time: Time.parse('2017-08-24 09:27:33 UTC'),
+          time_array: [ Time.parse('2017-08-24 10:00 UTC') ],
+          message: {
+            blob: 'blob',
+            time: { now: Time.parse('2017-08-24 10:00 UTC') }
+          }
+        },
+        lambda { |message| "#{message.to_json}with_encoding" },
+        :with_encoding
+      ).format
+    end
+
+    it 'transforms all fields to the specified time format' do
+      expect(result).to eq(
+        "{\"current_time\":\"2017-08-24T17:27:33.000+08:00\""\
+        ",\"time_array\":[\"2017-08-24T18:00:00.000+08:00\"],\"message\":{\"blob"\
+        "\":\"blob\",\"time\":{\"now\":\"2017-08-24T18:00:00.000+08:00\"}}}with_encoding"
+      )
     end
   end
 end

--- a/spec/pheromone/messaging/message_spec.rb
+++ b/spec/pheromone/messaging/message_spec.rb
@@ -30,11 +30,13 @@ describe Pheromone::Messaging::Message do
       message_object = described_class.new(
         topic: @topic,
         blob: @message,
-        options: @options
+        options: @options,
+        encoder: nil,
+        message_format: nil
       )
       expect(WaterDrop::SyncProducer).to receive(:call).with(
         {
-          'timestamp' => '2015-07-14T10:10:00.000+08:00',
+          'metadata' => {},
           'blob' => {
             'server_time' => nil,
             'message_data' => {
@@ -54,12 +56,13 @@ describe Pheromone::Messaging::Message do
       message_object = described_class.new(
         topic: @topic,
         blob: @message,
-        metadata: @meta_data
+        metadata: @meta_data,
+        encoder: nil,
+        message_format: nil
       )
       expect(WaterDrop::SyncProducer).to receive(:call).with(
         {
-          'event_name' => 'create',
-          'timestamp' => '2015-07-14T10:10:00.000+08:00',
+          'metadata' => { 'event_name' => 'create' },
           'blob' => {
             'server_time' => nil,
             'message_data' => {
@@ -80,12 +83,13 @@ describe Pheromone::Messaging::Message do
         topic: @topic,
         blob: @message,
         metadata: @meta_data,
-        options: @options
+        options: @options,
+        encoder: nil,
+        message_format: nil
       )
       expect(WaterDrop::SyncProducer).to receive(:call).with(
         {
-          'event_name' => 'create',
-          'timestamp' => '2015-07-14T10:10:00.000+08:00',
+          'metadata' => { 'event_name' => 'create' },
           'blob' => {
             'server_time' => nil,
             'message_data' => {

--- a/spec/pheromone/messaging/message_spec.rb
+++ b/spec/pheromone/messaging/message_spec.rb
@@ -32,7 +32,8 @@ describe Pheromone::Messaging::Message do
         blob: @message,
         options: @options,
         encoder: nil,
-        message_format: nil
+        message_format: nil,
+        embed_blob: nil
       )
       expect(WaterDrop::SyncProducer).to receive(:call).with(
         {
@@ -58,7 +59,8 @@ describe Pheromone::Messaging::Message do
         blob: @message,
         metadata: @meta_data,
         encoder: nil,
-        message_format: nil
+        message_format: nil,
+        embed_blob: nil
       )
       expect(WaterDrop::SyncProducer).to receive(:call).with(
         {
@@ -85,7 +87,8 @@ describe Pheromone::Messaging::Message do
         metadata: @meta_data,
         options: @options,
         encoder: nil,
-        message_format: nil
+        message_format: nil,
+        embed_blob: nil
       )
       expect(WaterDrop::SyncProducer).to receive(:call).with(
         {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'with_model'
 require 'rails/railtie'
 require 'waterdrop'
 require 'pheromone/frameworks/rspec'
+require 'pry-byebug'
 
 RSpec.configure do |config|
   config.extend WithModel

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ require 'with_model'
 require 'rails/railtie'
 require 'waterdrop'
 require 'pheromone/frameworks/rspec'
-require 'pry-byebug'
 
 RSpec.configure do |config|
   config.extend WithModel


### PR DESCRIPTION
## Why is this change necessary?

- `pheromone` does not allow avro encoding

## How does it address the issue?

- Allow producers to pass encoder so that pheromone can encode the messages

## What side effects does this change have?

- none

