### PR TITLE
Allow using custom processor in async mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Edit this file to modify the default config. The following configuration options
 |-------------------------------|---------------|----------------------------------|
 | background_processor.name     | Symbol        | Choose :sidekiq or :resque as the background processor only if messages need to be sent to kafka asynchronously |
 | background_processor.klass    | String        | Background processor class name that sends messages to kafka |
+| background_processor.custom_processor |Proc| Custom processor (only works when you specify name as :custom) |
 | timezone_format               | String        | Valid timezone name for timestamps sent to kafka |
 | message_format                | Symbol        | Only supports :json format currently |
 | enabled                       | Boolean       | Defaults to true. When this is set to false, no messages will be sent to Kafka |
@@ -117,7 +118,7 @@ Create a new class and add the name under `Pheromone.config.background_processor
    end
  end
 ```
-### 1.c. Implement your own processor
+#### 1.c. Implement your own processor
 You can also implement your own processor in addition to resque and sidekiq.
 ```ruby
   Pheromone.setup do |config|

--- a/lib/pheromone/config.rb
+++ b/lib/pheromone/config.rb
@@ -12,6 +12,8 @@ module Pheromone
       setting :name
       # specify the background job handling message send to kafka
       setting :klass
+      # specify custom background job (the name should be left empty)
+      setting :custom_processor
     end
     # timezone names should match a valid timezone defined here:
     # http://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html

--- a/lib/pheromone/config.rb
+++ b/lib/pheromone/config.rb
@@ -8,10 +8,13 @@ module Pheromone
     setting :message_format, :json
     setting :enabled, true
     setting :background_processor do
+      # type: symbol
       # accepts :sidekiq or :resque as a value
       setting :name
+      # type: string
       # specify the background job handling message send to kafka
       setting :klass
+      # type: proc/lambda
       # specify custom background job
       setting :custom_processor
     end

--- a/lib/pheromone/config.rb
+++ b/lib/pheromone/config.rb
@@ -12,7 +12,7 @@ module Pheromone
       setting :name
       # specify the background job handling message send to kafka
       setting :klass
-      # specify custom background job (the name should be left empty)
+      # specify custom background job
       setting :custom_processor
     end
     # timezone names should match a valid timezone defined here:

--- a/spec/pheromone/messaging/message_dispatcher_spec.rb
+++ b/spec/pheromone/messaging/message_dispatcher_spec.rb
@@ -93,6 +93,65 @@ describe Pheromone::Messaging::MessageDispatcher do
         expect(@message[:options]).to eq({})
       end
     end
+
+    context 'use custom background processor' do
+      class CustomJob
+        def self.perform(topic:, message:, metadata: {}, options: {})
+          Pheromone::Messaging::Message.new(
+            topic: topic,
+            blob: message,
+            metadata: metadata,
+            options: options
+          ).send!
+        end
+      end
+
+      context 'message should be processed by custom processor' do
+        before do
+          Pheromone.setup do |config|
+            config.background_processor.name = :custom
+            config.background_processor.klass = 'CustomJob'
+            config.background_processor.custom_processor = -> (klass, msg) do
+              klass.perform(msg)
+            end
+          end
+
+          expect(CustomJob).to receive(:perform) do |klass, message|
+            @klass = klass
+            @message = message
+          end
+        end
+
+        it 'should not raise error if custom processor is specified' do
+          expect do
+            described_class.new(
+              message_parameters: message_parameters,
+              dispatch_method: :async
+            ).dispatch
+          end.to_not raise_error
+        end
+      end
+
+      context 'if no processor is specified' do
+        before do
+          Pheromone.setup do |config|
+            config.background_processor.name = nil
+          end
+
+          expect(CustomJob).to_not receive(:perform)
+        end
+
+        it 'raise error' do
+          expect do
+            described_class.new(
+              message_parameters: message_parameters,
+              dispatch_method: :async
+            ).dispatch
+          end.to raise_error
+        end
+      end
+    end
+
   end
 
   context 'using sync dispatch method' do

--- a/spec/pheromone/messaging/message_dispatcher_spec.rb
+++ b/spec/pheromone/messaging/message_dispatcher_spec.rb
@@ -151,7 +151,6 @@ describe Pheromone::Messaging::MessageDispatcher do
         end
       end
     end
-
   end
 
   context 'using sync dispatch method' do


### PR DESCRIPTION
Allow use to specify a custom processor in async mode:
```ruby
          Pheromone.setup do |config|
            config.background_processor.name = :custom
            config.background_processor.klass = 'CustomJob'
            config.background_processor.custom_processor = -> (klass, msg) do
              klass.perform(msg)
            end
          end
```
@ankitagupta12 